### PR TITLE
BC-17611

### DIFF
--- a/gre/adapter.go
+++ b/gre/adapter.go
@@ -205,8 +205,7 @@ func (a *GREAdapter) Close() error {
 	for _, shutdownChan := range a.shutdownChans {
 		close(shutdownChan)
 	}
-	_ = a.adapter.Close()
-	return nil
+	return a.adapter.Close()
 }
 
 const missThreshold = 10_000_000

--- a/health/health_check.go
+++ b/health/health_check.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"sync"
 	"time"
+
+	"github.com/banyansecurity/gre-go-windows/utils"
 )
 
 type ReachablePeers struct {
@@ -40,6 +42,8 @@ const (
 )
 
 func (hc *HealthCheck) promoter() {
+	defer utils.PanicCrash()
+
 	for {
 		time.Sleep(pollInterval)
 

--- a/utils/panic.go
+++ b/utils/panic.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"log/slog"
+	"runtime/debug"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+var (
+	FileLogger  *lumberjack.Logger
+	PanicLogger *slog.Logger
+)
+
+func PanicCrash() {
+	if r := recover(); r != nil {
+		PanicLogger.Error("panic detected",
+			"panic", r,
+			"stack", string(debug.Stack()),
+		)
+		FileLogger.Close()
+		panic(r)
+	}
+}


### PR DESCRIPTION
- Fix deadlock on wait group because lock held by `Close` and `sessionRunner`.
- Add `panic` logger in Goroutines.

Tested by injecting a `panic` and making sure a log is present in `gre.log` and getting new connector configs over and over in public IP mode.