### PR TITLE
BC-18693

### DIFF
--- a/health/health_check.go
+++ b/health/health_check.go
@@ -84,6 +84,10 @@ func (hc *HealthCheck) NumActual() int {
 	hc.RLock()
 	defer hc.RUnlock()
 
+	if hc.current == nil {
+		return 0
+	}
+
 	return len(hc.current.Peers)
 }
 


### PR DESCRIPTION
Reference:

```
[2026/01/15 14:26:33 IST] [INFO] (tunnel.configureGRERoutes:628) gre: added connector return route 100.121.0.7 -> 100.120.0.7
[2026/01/15 14:26:36 IST] [EROR] (utils.PanicCrash:11) panic detected: runtime error: invalid memory address or nil pointer dereference: stack trace: goroutine 30 [running]:
runtime/debug.Stack()
	C:/Users/Administrator/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.windows-amd64/src/runtime/debug/stack.go:26 +0x5e
[gitlab.com/banyan-security/common/utils.PanicCrash()](http://gitlab.com/banyan-security/common/utils.PanicCrash())
	C:/Users/Administrator/go/pkg/mod/gitlab.com/banyan-security/common@v1.55.1-0.20251222222036-d5f4a2da2671/utils/panic.go:13 +0x3f
panic({0x7ff72648b500?, 0x7ff7269c3b50?})
	C:/Users/Administrator/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.windows-amd64/src/runtime/panic.go:783 +0x132
http://github.com/banyansecurity/gre-go-windows/health.(*HealthCheck ).NumActual(0xc00026de30?)
	C:/Users/Administrator/go/pkg/mod/github.com/banyansecurity/gre-go-windows@v0.0.0-20251204231322-d9fc251ac1a0/health/health_check.go:87 +0x73
http://github.com/banyansecurity/gre-go-windows/gre.(*PacketRouting ).HealthCheck(0xc000216800)
	C:/Users/Administrator/go/pkg/mod/github.com/banyansecurity/gre-go-windows@v0.0.0-20251204231322-d9fc251ac1a0/gre/routing.go:126 +0x85
http://github.com/banyansecurity/gre-go-windows/gre.(*GREAdapter ).Status(0x1007ff7264d4b00?)
	C:/Users/Administrator/go/pkg/mod/github.com/banyansecurity/gre-go-windows@v0.0.0-20251204231322-d9fc251ac1a0/gre/adapter.go:111 +0x87
[gitlab.com/banyan-security/connector/tunnel.(*WindowsProvider](http://gitlab.com/banyan-security/connector/tunnel.(*WindowsProvider)).PingAccessTiers(0x1bf08eb000?, 0xc00009b860, 0x7ff72646bac0?)
	C:/Users/Administrator/Development/Go/src/gitlab.com/banyan-security/connector/tunnel/provider_windows.go:319 +0x31
[gitlab.com/banyan-security/connector/tunnel.(*provider](http://gitlab.com/banyan-security/connector/tunnel.(*provider)).PingAccessTiers(0xc0000f6500)
	C:/Users/Administrator/Development/Go/src/gitlab.com/banyan-security/connector/tunnel/provider.go:631 +0x8c
main.pingTask({0x7ff72661f530, 0xc0000f6500})
	C:/Users/Administrator/Development/Go/src/gitlab.com/banyan-security/connector/connector/main.go:290 +0x5d
created by main.LaunchPeriodicTasks in goroutine 1
	C:/Users/Administrator/Development/Go/src/gitlab.com/banyan-security/connector/connector/init_windows.go:36 +0x2a8
```